### PR TITLE
Fix missing Input error

### DIFF
--- a/fluent-plugin-http-heartbeat.gemspec
+++ b/fluent-plugin-http-heartbeat.gemspec
@@ -17,8 +17,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |s|
   s.name          = 'fluent-plugin-http-heartbeat'
-  s.version       = '0.0.4'
-  s.date          = '2016-02-28'
+  s.version       = '0.0.5'
+  s.date          = '2018-06-01'
   s.summary       = "Fluentd input plugin that responses with HTTP status 200. Can be used for elb healthcheck."
   s.description   = s.summary
   s.authors       = ['Junjie Chen']

--- a/lib/fluent/plugin/in_http_heartbeat.rb
+++ b/lib/fluent/plugin/in_http_heartbeat.rb
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 
+require 'fluent/input'
+
 module Fluent
   class HttpHeartbeatInput < Input
     Fluent::Plugin.register_input('http_heartbeat', self)


### PR DESCRIPTION
Hi, I found your plugin recently and when I tried I got NameError (`0.0.4/lib/fluent/plugin/in_http_heartbeat.rb:15:in '<module:Fluent>': uninitialized constant Fluent::Input (NameError)`)

I tested the change with fluentd v1.1.3 and v0.12.43, the plugin worked fine.

Can you ping me when I can see this change with gem install? Then I can remove the ugly workaround in my dockerfile.
